### PR TITLE
Add ShowReadOnlyCB boolean flag to walk.FileDialog

### DIFF
--- a/declarative/composite.go
+++ b/declarative/composite.go
@@ -8,6 +8,7 @@ package declarative
 
 import (
 	"github.com/lxn/walk"
+	"github.com/lxn/win"
 )
 
 type Composite struct {
@@ -50,12 +51,17 @@ type Composite struct {
 	// Composite
 
 	AssignTo    **walk.Composite
+	Border      bool
 	Expressions func() map[string]walk.Expression
 	Functions   map[string]func(args ...interface{}) (interface{}, error)
 }
 
 func (c Composite) Create(builder *Builder) error {
-	w, err := walk.NewComposite(builder.Parent())
+	var style uint32
+	if c.Border {
+		style |= win.WS_BORDER
+	}
+	w, err := walk.NewCompositeWithStyle(builder.Parent(), style)
 	if err != nil {
 		return err
 	}

--- a/declarative/gradientcomposite.go
+++ b/declarative/gradientcomposite.go
@@ -8,6 +8,7 @@ package declarative
 
 import (
 	"github.com/lxn/walk"
+	"github.com/lxn/win"
 )
 
 type GradientComposite struct {
@@ -50,6 +51,7 @@ type GradientComposite struct {
 	// GradientComposite
 
 	AssignTo    **walk.GradientComposite
+	Border      bool
 	Color1      Property
 	Color2      Property
 	Expressions func() map[string]walk.Expression
@@ -58,7 +60,11 @@ type GradientComposite struct {
 }
 
 func (gc GradientComposite) Create(builder *Builder) error {
-	w, err := walk.NewGradientComposite(builder.Parent())
+	var style uint32
+	if gc.Border {
+		style |= win.WS_BORDER
+	}
+	w, err := walk.NewGradientCompositeWithStyle(builder.Parent(), style)
 	if err != nil {
 		return err
 	}

--- a/examples/gradientcomposite/gradientcomposite.go
+++ b/examples/gradientcomposite/gradientcomposite.go
@@ -31,6 +31,7 @@ func main() {
 		Layout: HBox{Margins: Margins{100, 100, 100, 100}},
 		Children: []Widget{
 			GradientComposite{
+				Border: true,
 				Vertical: Bind("verticalCB.Checked"),
 				Color1:   Bind("rgb(c1RedSld.Value, c1GreenSld.Value, c1BlueSld.Value)"),
 				Color2:   Bind("rgb(c2RedSld.Value, c2GreenSld.Value, c2BlueSld.Value)"),

--- a/gradientcomposite.go
+++ b/gradientcomposite.go
@@ -22,7 +22,11 @@ type GradientComposite struct {
 }
 
 func NewGradientComposite(parent Container) (*GradientComposite, error) {
-	composite, err := NewComposite(parent)
+	return NewGradientCompositeWithStyle(parent, 0)
+}
+
+func NewGradientCompositeWithStyle(parent Container, style uint32) (*GradientComposite, error) {
+	composite, err := NewCompositeWithStyle(parent, style)
 	if err != nil {
 		return nil, err
 	}

--- a/scrollview.go
+++ b/scrollview.go
@@ -356,7 +356,10 @@ func ifContainerIsScrollViewDoCoolSpecialLayoutStuff(layout Layout) bool {
 						flags := parentLayout.LayoutFlags()
 
 						if !hsb && flags&GreedyHorz != 0 || !vsb && flags&GreedyVert != 0 {
-							parentLayout.Update(false)
+							// Because logic...
+							if win.IsAppThemed() {
+								parentLayout.Update(false)
+							}
 							return true
 						}
 					}


### PR DESCRIPTION
Currently, Walk provides no way to determine whether the user checked the read-only mode check box in open file dialogs or not, so it doesn't make much sense to show it by default.  This PR adds the ShowReadOnlyCB boolean flag to walk.FileDialog, which is false when initialised, and can be explicitly set to true if a developer really wants the box to be shown.  Maybe we should also add a way to retrieve the checked state after the user has chosen a file, but that isn't in the scope of my use case for today.

This is my first ever PR so let me know if I'm missing something :)